### PR TITLE
go.mod: add module definition

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/sunfish-shogi/bufseekio
+
+go 1.13
+
+require github.com/stretchr/testify v1.3.0


### PR DESCRIPTION
Having this file allows the Go modules system to detect
bufseekio as a dependency and other goodies like being
able to transfer it via the GOPROXY protocol.

Signed-off-by: Adrian Ratiu <adrian.ratiu@collabora.com>